### PR TITLE
Add sass handling

### DIFF
--- a/src/Commands/Pull.php
+++ b/src/Commands/Pull.php
@@ -71,13 +71,16 @@ class Pull extends Command
     private function installWatcherFiles()
     {
 
-        $oldDir      = __DIR__ . '/../WatcherFiles/';
-        $oldWatcher  = $oldDir . 'filewatcher.php';
-        $newWatcher  = getcwd() . '/.functions/filewatcher.php';
-        $oldGulpFile = $oldDir . 'gulpfile.js';
-        $newGulpFile = getcwd() . '/gulpfile.js';
+        $oldDir        = __DIR__ . '/../WatcherFiles/';
+        $oldWatcher    = $oldDir . 'filewatcher.php';
+        $newWatcher    = getcwd() . '/.functions/filewatcher.php';
+        $oldGulpFile   = $oldDir . 'gulpfile.js';
+        $newGulpFile   = getcwd() . '/gulpfile.js';
+        $oldGulpConfig = $oldDir . 'gulp.config.js';
+        $newGulpConfig = getcwd() . '/gulp.config.js';
 
         $this->installNodeDependencies();
+        $this->createFilesAndFolders();
 
         if (!is_dir(getcwd() . '/.functions')) {
             mkdir((getcwd() . '/.functions'), 0755, true);
@@ -85,6 +88,7 @@ class Pull extends Command
 
         copy($oldWatcher, $newWatcher);
         copy($oldGulpFile, $newGulpFile);
+        copy($oldGulpConfig, $newGulpConfig);
 
     }
 
@@ -262,7 +266,16 @@ class Pull extends Command
             passthru('npm install -g pnpm');
 
             // Install necessary gulp packages & sass
-            passthru('pnpm install -D gulp gulp-exec gulp-watch gulp-sass sass && pnpm install -g gulp-cli');
+            passthru('pnpm install -D gulp gulp-exec gulp-watch gulp-sass gulp-concat gulp-autoprefixer del@6.1.1 gulp-uglifycss gulp-rename sass && pnpm install -g gulp-cli');
+        } catch (Exception $e) {
+            echo $e->getMessage();
+        }
+    }
+
+    private function createFilesAndFolders()
+    {
+        try {
+            passthru('touch .gitignore && mkdir src && mkdir src/sass');
         } catch (Exception $e) {
             echo $e->getMessage();
         }

--- a/src/Commands/Pull.php
+++ b/src/Commands/Pull.php
@@ -2,6 +2,7 @@
 
 namespace Davytimmers\LightspeedCli\Commands;
 
+use Exception;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -76,7 +77,7 @@ class Pull extends Command
         $oldGulpFile = $oldDir . 'gulpfile.js';
         $newGulpFile = getcwd() . '/gulpfile.js';
 
-        passthru('npm install gulp gulp-exec gulp-watch && npm install -g gulp-cli');
+        $this->installNodeDependencies();
 
         if (!is_dir(getcwd() . '/.functions')) {
             mkdir((getcwd() . '/.functions'), 0755, true);
@@ -254,4 +255,16 @@ class Pull extends Command
         }
     }
 
+    private function installNodeDependencies()
+    {
+        try {
+            // Install pnpm for faster package management
+            passthru('npm install -g pnpm');
+
+            // Install necessary gulp packages & sass
+            passthru('pnpm install -D gulp gulp-exec gulp-watch gulp-sass sass && pnpm install -g gulp-cli');
+        } catch (Exception $e) {
+            echo $e->getMessage();
+        }
+    }
 }

--- a/src/Commands/Pull.php
+++ b/src/Commands/Pull.php
@@ -275,7 +275,8 @@ class Pull extends Command
     private function createFilesAndFolders()
     {
         try {
-            passthru('touch .gitignore && mkdir src && mkdir src/sass');
+            passthru('touch .gitignore && echo "/node_modules\nlightspeed-settings.json" >> .gitignore');
+            passthru('mkdir src && mkdir src/sass &&');
         } catch (Exception $e) {
             echo $e->getMessage();
         }

--- a/src/WatcherFiles/gulp.config.js
+++ b/src/WatcherFiles/gulp.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  app: {
+    name: 'shopmonkey',
+  },
+  css: {
+    sourcePaths: [
+      './src/sass/*.scss'
+    ],
+    exportPath: './assets/'
+  },
+  thirdParty: {
+    sassOptions: {
+      errLogToConsole: true,
+      outputStyle: 'expanded'
+    },
+    uglifyCssOptions: {
+      'maxLineLen': 312,
+      'uglyComments': true
+    }
+  }
+}

--- a/src/WatcherFiles/gulpfile.js
+++ b/src/WatcherFiles/gulpfile.js
@@ -1,24 +1,35 @@
 const gulp = require('gulp');
 const watch = require('gulp-watch');
 const exec = require('gulp-exec');
+const sass = require('gulp-sass')(require('sass'));
 
-const watcher = watch(['layouts/*.rain', 'pages/*.rain', 'snippets/*.rain', 'assets/*']);
+const watcher = watch(['layouts/*.rain', 'pages/*.rain', 'snippets/*.rain', 'assets/*', 'src/**/*']);
 
-gulp.task('watch', function() {
+gulp.task('watch', function () {
     var path = '';
-    watcher.on('change', function(path, stats) {
-        return gulp.src('/')
-            .pipe(exec('php ".functions/filewatcher.php" ' + '"' + path + '" change'))
-            .pipe(exec.reporter());
+    watcher.on('change', function (path, stats) {
+        if (path.endsWith('.scss')) {
+            gulp.parallel('sass')(path);
+        } else {
+            return gulp.src('/')
+                .pipe(exec('php ".functions/filewatcher.php" ' + '"' + path + '" change'))
+                .pipe(exec.reporter());
+        }
     });
-    watcher.on('add', function(path, stats) {
+    watcher.on('add', function (path, stats) {
         return gulp.src('/')
             .pipe(exec('php ".functions/filewatcher.php" ' + '"' + path + '" add'))
             .pipe(exec.reporter());
     });
-    watcher.on('unlink', function(path, stats) {
+    watcher.on('unlink', function (path, stats) {
         return gulp.src('/')
             .pipe(exec('php ".functions/filewatcher.php" ' + '"' + path + '" unlink'))
             .pipe(exec.reporter());
     });
+});
+
+gulp.task('sass', () => {
+    return gulp.src('src/sass/**/*.scss')
+        .pipe(sass().on('error', sass.logError))
+        .pipe(gulp.dest('./assets/'));
 });


### PR DESCRIPTION
Allows for scss bundling, minifying and autoprefixing.
You can add your scss files in the `./src/sass` directory.

Also automatically creates a `.gitignore` to ignore lightspeed-settings.json and node_modules.