### PR TITLE
Add VSCode recommendations and Prettier

### DIFF
--- a/src/Commands/Pull.php
+++ b/src/Commands/Pull.php
@@ -40,6 +40,7 @@ class Pull extends Command
 
         $this->installWatcherFiles();
         $this->addRecommendedExtensions();
+        $this->createPrettierConfig();
 
         $availableToPull = $this->availableToPull($settings);
         if (!$availableToPull) {
@@ -273,9 +274,35 @@ class Pull extends Command
         }
 
         // Create and write extensions json file
-        touch($pathName . '/extensions.json');
+        if (!file_exists($pathName . '/extensions.json')) {
+            touch($pathName . '/extensions.json');
+        }
+
         $extensionsFile = fopen($pathName . '/extensions.json', 'w');
         fwrite($extensionsFile, $extensionsString);
         fclose($extensionsFile);
+    }
+
+    private function createPrettierConfig()
+    {
+        $pathName       = getcwd();
+        $prettierConfig = [
+            'trailingComma'          => 'es5',
+            'tabWidth'               => 2,
+            'semi'                   => true,
+            'singleQuote'            => true,
+            'bracketSpacing'         => true,
+            'bracketSameLine'        => false,
+            'requirePragma'          => true,
+            'singleAttributePerLine' => true,
+        ];
+
+        if (!file_exists($pathName . '/.prettierrc.json')) {
+            touch($pathName . '/.prettierrc.json');
+        }
+
+        $prettierConfigFile = fopen($pathName . '/.prettierrc.json', 'w');
+        fwrite($prettierConfigFile, json_encode($prettierConfig, JSON_PRETTY_PRINT));
+        fclose($prettierConfigFile);
     }
 }

--- a/src/Commands/Pull.php
+++ b/src/Commands/Pull.php
@@ -39,7 +39,7 @@ class Pull extends Command
         $settings        = $settingsService->get($input, $output);
 
         $this->installWatcherFiles();
-        $this->addRecommended();
+        $this->addRecommendedExtensions();
 
         $availableToPull = $this->availableToPull($settings);
         if (!$availableToPull) {
@@ -255,7 +255,7 @@ class Pull extends Command
         }
     }
 
-    private function addRecommended()
+    private function addRecommendedExtensions()
     {
         $pathName         = getcwd() . '/.vscode';
         $extensions       = [

--- a/src/Commands/Pull.php
+++ b/src/Commands/Pull.php
@@ -39,6 +39,7 @@ class Pull extends Command
         $settings        = $settingsService->get($input, $output);
 
         $this->installWatcherFiles();
+        $this->addRecommended();
 
         $availableToPull = $this->availableToPull($settings);
         if (!$availableToPull) {
@@ -254,4 +255,27 @@ class Pull extends Command
         }
     }
 
+    private function addRecommended()
+    {
+        $pathName         = getcwd() . '/.vscode';
+        $extensions       = [
+            'recommendations' => [
+                'esbenp.prettier-vscode',
+                'dbaeumer.vscode-eslint',
+                'mblode.twig-language-2',
+                'formulahendry.auto-rename-tag'
+            ]
+        ];
+        $extensionsString = json_encode($extensions, JSON_PRETTY_PRINT);
+
+        if (!is_dir($pathName)) {
+            mkdir(($pathName), 0755, true);
+        }
+
+        // Create and write extensions json file
+        touch($pathName . '/extensions.json');
+        $extensionsFile = fopen($pathName . '/extensions.json', 'w');
+        fwrite($extensionsFile, $extensionsString);
+        fclose($extensionsFile);
+    }
 }


### PR DESCRIPTION
Added VSCode extension recommendations and a Prettier config (for JS formatting)!🎉
The following settings were added to the Prettier config, we can of course always change this later:
- trailingComma
- tabWidth
- semi
- singleQuote
- bracketSpacing
- bracketSameLine
- requirePragma
- singleAttributePerLine

For an overview of what the settings do you can check [the Prettier docs](https://prettier.io/docs/en/options).